### PR TITLE
solving the preview/preload problem:

### DIFF
--- a/src/self_destruct/message/handler.clj
+++ b/src/self_destruct/message/handler.clj
@@ -13,7 +13,7 @@
         message-id (message.model/create-message! db-url {:message message})]
     (do
       (timbre/info (str "message created: " (util/uuid->str message-id)))
-      (message.view.link/link-page (util/uuid->str message-id)))))
+      (response/redirect (str "/message/link/" (util/uuid->str message-id))))))
 
 
 (defn handle-delete-message! [req]
@@ -26,6 +26,11 @@
       (do
         (timbre/error (str "message delete failed message id not found: " message-id))
         (response/not-found "Message not found.")))))
+
+
+(defn handle-view-message-link [req]
+  (let [message-id (java.util.UUID/fromString (:message-id (:route-params req)))]
+    (message.view.link/link-page message-id)))
 
 
 (defn handle-fetch-message [req]

--- a/src/self_destruct/message/route.clj
+++ b/src/self_destruct/message/route.clj
@@ -6,4 +6,5 @@
 (defroutes message-routes
   (POST "/message/create"             [] message.handler/handle-create-message!)
   (POST "/message/delete/:message-id" [] message.handler/handle-delete-message!)
+  (GET  "/message/link/:message-id"   [] message.handler/handle-view-message-link)
   (GET  "/message/fetch/:message-id"  [] message.handler/handle-fetch-message))

--- a/src/self_destruct/message/view/link.clj
+++ b/src/self_destruct/message/view/link.clj
@@ -7,9 +7,7 @@
   (let [message-link (str "/message/fetch/" message-id)]
     (home.view.layout/page-layout
      (html
-      [:div#tagline
-       "create read-once, self-destructing, messages."]
-
       [:div.content
-       [:p "Send this link to the recipient, the message can only be viewed ONCE."]
+       [:p "Send a link to THIS page to the recipient and NOT the link below."]
+       [:p "The message can only be viewed ONCE."]
        [:p [:a {:href message-link} "message link"]]]))))


### PR DESCRIPTION
this solves the preview/preload problem when sending the message link
via slack, imessage, etc.  there's now one layer of indirection so you
link to message/link/id page and the link to the message is there.