### PR TITLE
Finish contrib enhancements: encryption, expiry, health, safer ops

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,38 +49,28 @@ jobs:
             DATABASE_URL: "jdbc:postgresql://self-destruct:@localhost:5432/self-destruct-test"
           command: lein test
 
-  deploy-prod:
-    working_directory: ~/self-destruct
-    docker:
-      - image: circleci/clojure:lein-2.9.0
-    steps:
-      - checkout
-      - run:
-          name: setup heroku
-          command: bash .circleci/setup-heroku.sh
-      - add_ssh_keys:
-          fingerprints:
-            - "7e:f6:06:60:8b:d5:b3:e9:76:d7:9a:1f:fd:c4:d2:aa"
+  # deploy-prod:
+  #   working_directory: ~/self-destruct
+  #   docker:
+  #     - image: circleci/clojure:lein-2.9.0
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: setup heroku
+  #         command: bash .circleci/setup-heroku.sh
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - "7e:f6:06:60:8b:d5:b3:e9:76:d7:9a:1f:fd:c4:d2:aa"
 
 
-workflows:
-  version: 2
-  build-deploy:
-    jobs:
-      - build
-      - deploy-prod:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-  build-deploy-from-feature-branch:
-    jobs:
-      - build
-      - deploy-prod:
-          requires:
-            - build
-          type: approval
-          filters:
-            branches:
-              ignore: master
+# workflows:
+#   version: 2
+#   build-deploy:
+#     jobs:
+#       - build
+#       - deploy-prod:
+#           requires:
+#             - build
+#           filters:
+#             branches:
+#               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
           POSTGRES_USER: self-destruct
           POSTGRES_DB: self-destruct-test
           POSTGRES_PASSWORD: ""
+          # POSTGRES_HOST: postgres
+          DATABASE_ENCRYPTION_KEY: "changemedbkey1"
+          SESSION_COOKIE_KEY: "changecookiekey1"
 
     working_directory: ~/self-destruct
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,29 +48,3 @@ jobs:
           environment:
             DATABASE_URL: "jdbc:postgresql://self-destruct:@localhost:5432/self-destruct-test"
           command: lein test
-
-  # deploy-prod:
-  #   working_directory: ~/self-destruct
-  #   docker:
-  #     - image: circleci/clojure:lein-2.9.0
-  #   steps:
-  #     - checkout
-  #     - run:
-  #         name: setup heroku
-  #         command: bash .circleci/setup-heroku.sh
-  #     - add_ssh_keys:
-  #         fingerprints:
-  #           - "7e:f6:06:60:8b:d5:b3:e9:76:d7:9a:1f:fd:c4:d2:aa"
-
-
-# workflows:
-#   version: 2
-#   build-deploy:
-#     jobs:
-#       - build
-#       - deploy-prod:
-#           requires:
-#             - build
-#           filters:
-#             branches:
-#               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,3 +74,13 @@ workflows:
           filters:
             branches:
               only: master
+  build-deploy-from-feature-branch:
+    jobs:
+      - build
+      - deploy-prod:
+          requires:
+            - build
+          type: approval
+          filters:
+            branches:
+              ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,14 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/clojure:lein-2.9.0
+        environment:
+          LEIN_ROOT: "true"
+          JVM_OPTS: -Xmx3200m
+          DATABASE_URL: "jdbc:postgresql://self-destruct:@localhost:5432/self-destruct-test"
+          DATABASE_ENCRYPTION_KEY: "changemedbkey2"
+          SESSION_COOKIE_KEY: "changecookiekey2"
+          DISABLE_ANTI_FORGERY: "true"
+          ENABLE_WORKERS: "false"
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -17,16 +25,8 @@ jobs:
           POSTGRES_USER: self-destruct
           POSTGRES_DB: self-destruct-test
           POSTGRES_PASSWORD: ""
-          # POSTGRES_HOST: postgres
-          DATABASE_ENCRYPTION_KEY: "changemedbkey1"
-          SESSION_COOKIE_KEY: "changecookiekey1"
 
     working_directory: ~/self-destruct
-
-    environment:
-      LEIN_ROOT: "true"
-      # Customize the JVM maximum heap limit
-      JVM_OPTS: -Xmx3200m
 
     steps:
       - checkout
@@ -45,9 +45,22 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "project.clj" }}
 
-      # run tests!
+      - run:
+          name: wait for postgres
+          command: |
+            for i in $(seq 1 30); do
+              if (echo > /dev/tcp/localhost/5432) >/dev/null 2>&1; then
+                exit 0
+              fi
+              sleep 1
+            done
+            echo "postgres did not become ready in time" >&2
+            exit 1
+
+      - run:
+          name: run database migrations
+          command: lein migrate
+
       - run:
           name: run leiningen tests
-          environment:
-            DATABASE_URL: "jdbc:postgresql://self-destruct:@localhost:5432/self-destruct-test"
           command: lein test

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JVM_OPTS -cp target/self-destruct.jar --port $PORT
+web: java $JVM_OPTS -jar target/self-destruct.jar --port $PORT

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,5 @@
+# main app
 web: java $JVM_OPTS -jar target/self-destruct.jar --port $PORT
+
+# run db migrations before release
 release: java $JVM_OPTS -jar target/self-destruct.jar --migrate

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: java $JVM_OPTS -jar target/self-destruct.jar --port $PORT
+worker: java $JVM_OPTS -jar target/self-destruct.jar --migrate

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: java $JVM_OPTS -jar target/self-destruct.jar --port $PORT
-worker: java $JVM_OPTS -jar target/self-destruct.jar --migrate
+release: java $JVM_OPTS -jar target/self-destruct.jar --migrate

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JVM_OPTS -cp target/self-destruct.jar clojure.main -m self-destruct.core $PORT
+web: java $JVM_OPTS -cp target/self-destruct.jar --port $PORT

--- a/README.org
+++ b/README.org
@@ -23,12 +23,12 @@
 
     #+BEGIN_SRC sh
       createdb self-destruct-dev
-      lein migratus migrate
+      lein migrate
     #+END_SRC
 
 *** One alias to rule them all
 
-    This alias should do all that is necessary in one step for local development.
+    This alias should do all that is necessary in one step for local development, once migrations have been run.
 
     #+BEGIN_SRC sh
       lein dev

--- a/README.org
+++ b/README.org
@@ -63,6 +63,7 @@
    you'll need to load the following environment variables in your production environment:
 
    - ~DATABASE_URL~
+   - ~DATABASE_ENCRYPTION_KEY~
    - ~PORT~
    - ~SESSION_COOKIE_KEY~
 

--- a/README.org
+++ b/README.org
@@ -19,12 +19,15 @@
 
 *** Setup Local Development Database
 
-    self-destruct uses postgresql; you'll need this availalbe for local dev.  to create a local dev database run the following commands.
+    self-destruct uses postgresql; you'll need this available for local dev.  to create a local dev database run the following commands.
 
     #+BEGIN_SRC sh
       createdb self-destruct-dev
+      export DATABASE_URL=jdbc:postgresql://localhost:5432/self-destruct-dev?user=USER&password=PASSWORD
       lein migrate
     #+END_SRC
+
+    JDBC connections typically need a username/password (peer auth via Unix sockets is not used). Update ~profiles.clj~ and ~DATABASE_URL~ to match your local Postgres role.
 
 *** One alias to rule them all
 
@@ -48,14 +51,20 @@
       lein garden auto
     #+END_SRC
 
+*** Running Tests
+
+    #+BEGIN_SRC sh
+      ./run-tests-local.sh
+    #+END_SRC
+
 
 ** Database Migrations
 
    - the clojure migratus library is used to handle db schema changes.
    - migrations are located in the ~resources/migrations~ folder.
    - to create a new migration ~lein migratus create <descriptive-name>~ and then edit the ~up~ and ~down~ files created.
-   - migrations are applied automatically see config.clj and core.clj
-   - to manually apply migrations to your local dev instance ~lein migratus migrate~
+   - migrations are applied via ~lein migrate~ (local) or ~java -jar self-destruct.jar --migrate~ (production / Heroku release phase).
+   - for local development set ~DATABASE_URL~ to a JDBC URL Postgres will accept over TCP.
 
 
 ** Production Setup
@@ -69,9 +78,12 @@
 
    optionally you can customize the following variables in your production environment:
 
-   - ~REPORTED_LOG_LEVEL~ (defaults to "warn"; set's min level to write to production log)
+   - ~REPORTED_LOG_LEVEL~ (defaults to "warn"; sets min level to write to production log when using Sentry)
    - ~LOG_APPENDER~ (options "println" "sentry")
    - ~SENTRY_DSN~ (required only if you've set log-appender to "sentry")
+   - ~ENABLE_WORKERS~ (defaults to enabled; set to ~false~ to disable background workers)
+   - ~MESSAGE_EXPIRE_MINUTES~ (defaults to ~1440~ / 24 hours)
+   - ~WORKER_DELAY_SECONDS~ (defaults to ~3600~ / 1 hour)
 
 
 ** License

--- a/profiles_example.clj
+++ b/profiles_example.clj
@@ -1,10 +1,15 @@
 {:profiles/dev
  {:env
   {:database-url "jdbc:postgresql://localhost/self-destruct-dev"
+   :database-encryption-key "changemedbkey1"
    :reported-log-level "debug"
    :session-cookie-key "changecookiekey1"}}
  :profiles/test
  {:env
   {:database-url "jdbc:postgresql://localhost/self-destruct-test"
+   :database-encryption-key "changemedbkey2"
    :reported-log-level "debug"
-   :session-cookie-key "changecookiekey2"}}}
+   :session-cookie-key "changecookiekey2"}}
+ :profiles/prod
+ ;; intentionally empty to ensure builds do not rely on run time values
+ {:env {}}}

--- a/profiles_example.clj
+++ b/profiles_example.clj
@@ -1,15 +1,20 @@
 {:profiles/dev
  {:env
-  {:database-url "jdbc:postgresql://localhost/self-destruct-dev"
+  {:database-url "jdbc:postgresql://localhost:5432/self-destruct-dev?user=selfdestruct&password=selfdestruct"
    :database-encryption-key "changemedbkey1"
    :reported-log-level "debug"
-   :session-cookie-key "changecookiekey1"}}
+   :session-cookie-key "changecookiekey1"
+   :enable-workers "false"
+   :message-expire-minutes "1440"
+   :worker-delay-seconds "3600"}}
  :profiles/test
  {:env
-  {:database-url "jdbc:postgresql://localhost/self-destruct-test"
+  {:database-url "jdbc:postgresql://localhost:5432/self-destruct-test?user=selfdestruct&password=selfdestruct"
    :database-encryption-key "changemedbkey2"
    :reported-log-level "debug"
-   :session-cookie-key "changecookiekey2"}}
+   :session-cookie-key "changecookiekey2"
+   :disable-anti-forgery "true"
+   :enable-workers "false"}}
  :profiles/prod
  ;; intentionally empty to ensure builds do not rely on run time values
  {:env {}}}

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,8 @@
             [lein-pdo "0.1.1"]]
 
 
-  :ring {:handler self-destruct.core/app
+  :ring {:init mutual-note.core/init
+         :handler self-destruct.core/app
          :port 8000
          :auto-refresh? true}
 

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [compojure "1.6.1"]
                  ;;; environment
                  [environ "1.1.0"]
+                 [org.clojure/tools.cli "0.4.2"]
                  ;;; database
                  [com.layerware/hugsql "0.4.9"]
                  [org.postgresql/postgresql "42.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
             [lein-pdo "0.1.1"]]
 
 
-  :ring {:init mutual-note.core/init
+  :ring {:init self-destruct.core/init
          :handler self-destruct.core/app
          :port 8000
          :auto-refresh? true}

--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,7 @@
 
 
   :aliases {"migrate" ["migratus" "migrate"]
-            "dev"     ["pdo" ["garden" "auto"] ["ring" "server"]]}
+            "dev"     ["pdo" ["garden" "auto"] ["ring" "server-headless"]]}
 
 
   )

--- a/project.clj
+++ b/project.clj
@@ -17,12 +17,16 @@
                  [com.taoensso/timbre "4.10.0"]
                  [raven-clj "1.5.2"] ; timbre sentry support
                  ;;; security
-                 [buddy "2.0.0"]
+                 [buddy/buddy-core "1.6.0"]
                  ;;; ui
                  [hiccup "1.0.5"]
                  [garden "1.3.9"]
                  ;;; middleware
                  [ring/ring-defaults "0.3.2"]
+                 ;;; data
+                 [cheshire "5.8.1"]
+                 ;;; scheduling
+                 [tea-time "1.0.1"]
                  ;;; hosted assests
                  [ring-webjars "0.2.0"]
                  [org.webjars/font-awesome "5.8.2"]]
@@ -66,8 +70,8 @@
              :profiles/test {}
              :profiles/prod {}
              :project/dev {:main self-destruct.core/-dev-main
-                           :dependencies [[ring/ring-mock "0.3.2"]]}
-             :project/test {:dependencies[[ring/ring-mock "0.3.2"]]}
+                           :dependencies [[ring/ring-mock "0.4.0"]]}
+             :project/test {:dependencies[[ring/ring-mock "0.4.0"]]}
              :project/prod {}}
 
 

--- a/project.clj
+++ b/project.clj
@@ -57,7 +57,8 @@
 
   :migratus {:store :database
              :migration-dir "migrations"
-             :db ~(get (System/getenv) "DATABASE_URL")}
+             :db {:connection-uri ~(or (System/getenv "DATABASE_URL")
+                                       "jdbc:postgresql://localhost:5432/self-destruct-dev?user=selfdestruct&password=selfdestruct")}}
 
 
   :profiles {:uberjar {:aot :all

--- a/resources/migrations/20190821144044-add-message-iv.down.sql
+++ b/resources/migrations/20190821144044-add-message-iv.down.sql
@@ -1,0 +1,2 @@
+alter table message
+drop column if exists message_iv;

--- a/resources/migrations/20190821144044-add-message-iv.up.sql
+++ b/resources/migrations/20190821144044-add-message-iv.up.sql
@@ -1,0 +1,2 @@
+alter table message
+add column message_iv char(32) not null;

--- a/resources/migrations/20190821144044-add-message-iv.up.sql
+++ b/resources/migrations/20190821144044-add-message-iv.up.sql
@@ -1,2 +1,6 @@
+-- existing plaintext messages cannot be encrypted without their cleartext keying
+-- material; purge unread notes before requiring an IV column
+delete from message;
+--;;
 alter table message
 add column message_iv char(32) not null;

--- a/run-tests-local.sh
+++ b/run-tests-local.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[[ -n $(psql -l | grep self-destruct-test) ]] && dropdb self-destruct-test
+createdb self-destruct-test
+lein with-profile test migrate && lein test

--- a/run-tests-local.sh
+++ b/run-tests-local.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
+set -e
 
-[[ -n $(psql -l | grep self-destruct-test) ]] && dropdb self-destruct-test
+export DATABASE_URL="${DATABASE_URL:-jdbc:postgresql://localhost:5432/self-destruct-test?user=selfdestruct&password=selfdestruct}"
+
+if psql -lqt | cut -d \| -f 1 | grep -qw self-destruct-test; then
+  dropdb self-destruct-test
+fi
+
 createdb self-destruct-test
-lein with-profile test migrate && lein test
+lein migrate
+lein with-profile test test

--- a/src/self_destruct/config.clj
+++ b/src/self_destruct/config.clj
@@ -6,32 +6,32 @@
 
 
 ;; database config
-(def db-url
+(defn db-url []
   (environ/env :database-url))
 
 
 ;; migrations
-(def db-migration-config
+(defn db-migration-config []
   {:store         :database
    :migration-dir "migrations"
-   :db            db-url})
+   :db            (db-url)})
 
 (defn run-db-migration []
   ;; apply pending migrations
-  (migratus/migrate db-migration-config))
+  (migratus/migrate (db-migration-config)))
 
 
 ;; session cookie security config
-(def session-cookie-key
+(defn session-cookie-key []
   (environ/env :session-cookie-key))
 
 
 ;; logging config
-(def reported-log-level
+(defn reported-log-level []
   (keyword (or (environ/env :reported-log-level) "warn")))
 
 
-(def log-appender
+(defn log-appender []
   (or (environ/env :log-appender) "println"))
 
 
@@ -39,8 +39,8 @@
   (timbre/merge-config!
    {:appenders
     (cond
-      (= "println" log-appender) {:println {:output-fn :inherit}}
-      (= "sentry" log-appender)  {:sentry-appender
-                                  (merge
-                                   (sentry/sentry-appender (environ/env :sentry-dsn))
-                                   {:min-level reported-log-level})})}))
+      (= "println" (log-appender)) {:println {:output-fn :inherit}}
+      (= "sentry" (log-appender))  {:sentry-appender
+                                    (merge
+                                     (sentry/sentry-appender (environ/env :sentry-dsn))
+                                     {:min-level (reported-log-level)})})}))

--- a/src/self_destruct/config.clj
+++ b/src/self_destruct/config.clj
@@ -24,6 +24,19 @@
   (migratus/migrate (db-migration-config)))
 
 
+;; jetty config
+(defn jetty-https-config [port]
+  {:ssl?           true
+   :ssl-port       (Integer/valueOf port)
+   :keystore       (environ/env :keystore)
+   :truststore     (environ/env :truststore)
+   :key-password   "changeit"
+   :trust-password "changeit"})
+
+(defn jetty-http-config [port]
+  {:port (Integer/valueOf port)})
+
+
 ;; session cookie security config
 (defn session-cookie-key []
   (environ/env :session-cookie-key))

--- a/src/self_destruct/config.clj
+++ b/src/self_destruct/config.clj
@@ -9,6 +9,9 @@
 (defn db-url []
   (environ/env :database-url))
 
+(defn db-encryption-key []
+  (environ/env :database-encryption-key))
+
 
 ;; migrations
 (defn db-migration-config []

--- a/src/self_destruct/core.clj
+++ b/src/self_destruct/core.clj
@@ -1,6 +1,7 @@
 (ns self-destruct.core
   (:require [self-destruct.config :as config]
-            [self-destruct.route  :as route])
+            [self-destruct.route  :as route]
+            [self-destruct.worker :as worker])
   (:require [clojure.tools.cli              :refer [parse-opts]]
             [environ.core                   :as    environ]
             [ring.adapter.jetty             :as    jetty]
@@ -17,7 +18,9 @@
 (defn init []
   (do
     ;; load logging configuration prior to app load
-    (config/configure-logging)))
+    (config/configure-logging)
+    ;; kick off worker processes
+    (worker/launch-workers)))
 
 
 ;; define main application
@@ -29,6 +32,7 @@
        (-> (if (= "true" (environ/env :secure-defaults))
              secure-site-defaults
              site-defaults)
+           ;; (assoc-in [:security :anti-forgery] false)
            (assoc-in [:session :store] (cookie-store {:key (config/session-cookie-key)}))
            (assoc-in [:session :cookie-attrs] {:max-age 3600})
            (assoc :proxy true)))

--- a/src/self_destruct/core.clj
+++ b/src/self_destruct/core.clj
@@ -17,9 +17,7 @@
 (defn init []
   (do
     ;; load logging configuration prior to app load
-    (config/configure-logging)
-    ;; run database migrations prior to app load
-    (config/run-db-migration)))
+    (config/configure-logging)))
 
 
 ;; define main application

--- a/src/self_destruct/core.clj
+++ b/src/self_destruct/core.clj
@@ -1,13 +1,15 @@
 (ns self-destruct.core
   (:require [self-destruct.config :as config]
             [self-destruct.route  :as route])
-  (:require [environ.core                   :as    environ]
+  (:require [clojure.tools.cli              :refer [parse-opts]]
+            [environ.core                   :as    environ]
             [ring.adapter.jetty             :as    jetty]
             [ring.middleware.defaults       :refer :all]
             [ring.middleware.webjars        :refer [wrap-webjars]]
             [ring.middleware.resource       :refer [wrap-resource]]
             [ring.middleware.reload         :refer [wrap-reload]]
-            [ring.middleware.session.cookie :refer [cookie-store]])
+            [ring.middleware.session.cookie :refer [cookie-store]]
+            [taoensso.timbre                :as    timbre])
   (:gen-class))
 
 
@@ -36,23 +38,58 @@
       wrap-webjars))
 
 
+;; command line options and validation
+(def cli-options
+  [["-p" "--port PORT" "Port number"
+    :default 8000
+    ;; first parse our option
+    :parse-fn #(Integer/parseInt %)
+    ;; then validate our option
+    :validate [#(< 0 % 65536) "Must be a number between 0 and 65536"]]
+   ;; defaults to nil
+   ["-m" "--migrate"]
+   ;; defaults to nil
+   ["-h" "--help"]])
+
+
 ;; main application entry point
-(defn -main
-  ([]     (-main 8000))
-  ([port] (do
-            (timbre/info "running init tasks")
-            (init)
-            (timbre/info (str "starting the app on port " port "..."))
-            (jetty/run-jetty app
-                             {:port (Integer. port)}))))
+(defn -main [& args]
+  (let [{:keys [options arguments summary errors]} (parse-opts args cli-options)
+        port   (:port options)]
+    (cond
+      errors
+      (do
+        (timbre/error errors)
+        (timbre/info summary)
+        (System/exit 1))
+
+      (:help options)
+      (do
+        (timbre/info summary)
+        (System/exit 0))
+
+      (:migrate options)
+      (do
+        (timbre/info "running database migrations...")
+        (config/run-db-migration)
+        (System/exit 0))
+
+      :else
+      (do
+        (timbre/info "running init tasks")
+        (init)
+        (timbre/info (str "starting the app on port " port "..."))
+        (jetty/run-jetty app
+                         {:port (Integer. port)})))))
 
 
 ;; development mode main application entry point
-(defn -dev-main
-  ([]     (-dev-main 8000))
-  ([port] (do
-            (timbre/info "DEV: running init tasks")
-            (init)
-            (timbre/info (str "DEV: starting the app on port " port "..."))
-            (jetty/run-jetty (wrap-reload #'app)
-                             {:port (Integer. port)}))))
+(defn -dev-main [& args]
+  (let [{:keys [options arguments summary errors]} (parse-opts args cli-options)
+        port   (:port options)]
+    (do
+      (timbre/info "DEV: running init tasks")
+      (init)
+      (timbre/info (str "DEV: starting the app on port " port "..."))
+      (jetty/run-jetty (wrap-reload #'app)
+                       {:port (Integer. port)}))))

--- a/src/self_destruct/core.clj
+++ b/src/self_destruct/core.clj
@@ -31,7 +31,7 @@
        (-> (if (= "true" (environ/env :secure-defaults))
              secure-site-defaults
              site-defaults)
-           (assoc-in [:session :store] (cookie-store {:key config/session-cookie-key}))
+           (assoc-in [:session :store] (cookie-store {:key (config/session-cookie-key)}))
            (assoc-in [:session :cookie-attrs] {:max-age 3600})
            (assoc :proxy true)))
       ;; set path for webjar assets

--- a/src/self_destruct/core.clj
+++ b/src/self_destruct/core.clj
@@ -80,7 +80,7 @@
         (init)
         (timbre/info (str "starting the app on port " port "..."))
         (jetty/run-jetty app
-                         {:port (Integer. port)})))))
+                         {:port (Integer/valueOf port)})))))
 
 
 ;; development mode main application entry point
@@ -92,4 +92,4 @@
       (init)
       (timbre/info (str "DEV: starting the app on port " port "..."))
       (jetty/run-jetty (wrap-reload #'app)
-                       {:port (Integer. port)}))))
+                       {:port (Integer/valueOf port)}))))

--- a/src/self_destruct/core.clj
+++ b/src/self_destruct/core.clj
@@ -7,7 +7,6 @@
             [ring.adapter.jetty             :as    jetty]
             [ring.middleware.defaults       :refer :all]
             [ring.middleware.webjars        :refer [wrap-webjars]]
-            [ring.middleware.resource       :refer [wrap-resource]]
             [ring.middleware.reload         :refer [wrap-reload]]
             [ring.middleware.session.cookie :refer [cookie-store]]
             [taoensso.timbre                :as    timbre])
@@ -32,7 +31,9 @@
        (-> (if (= "true" (environ/env :secure-defaults))
              secure-site-defaults
              site-defaults)
-           ;; (assoc-in [:security :anti-forgery] false)
+           ;; allow tests to disable csrf; remains enabled for normal app use
+           (assoc-in [:security :anti-forgery]
+                     (not= "true" (environ/env :disable-anti-forgery)))
            (assoc-in [:session :store] (cookie-store {:key (config/session-cookie-key)}))
            (assoc-in [:session :cookie-attrs] {:max-age 3600})
            (assoc :proxy true)))
@@ -58,6 +59,8 @@
 (defn -main [& args]
   (let [{:keys [options arguments summary errors]} (parse-opts args cli-options)
         port   (:port options)]
+    ;; configure logging for all entrypoints (help/migrate/server)
+    (config/configure-logging)
     (cond
       errors
       (do
@@ -79,7 +82,8 @@
       :else
       (do
         (timbre/info "running init tasks")
-        (init)
+        ;; workers only; logging already configured above
+        (worker/launch-workers)
         (timbre/info (str "starting the app on port " port "..."))
         (jetty/run-jetty app
                          {:port (Integer/valueOf port)})))))

--- a/src/self_destruct/health/handler.clj
+++ b/src/self_destruct/health/handler.clj
@@ -1,0 +1,18 @@
+(ns self-destruct.health.handler
+  (:require [self-destruct.health.model :as health.model]
+            [self-destruct.config       :as config])
+  (:require [cheshire.core :as json]))
+
+
+(defn handle-health [req]
+  {:status 200
+   :headers {"Content-Type" "application/json"}
+   :body (json/generate-string {:healthy true})})
+
+
+(defn handle-deep-health [req]
+  (let [healthy? (get (health.model/deep-health (config/db-url)) :exists)]
+    {:status 200
+     :headers {"Content-Type" "application/json"}
+     :body (json/generate-string {:healthy healthy?
+                                  :check-type "database connection"})}))

--- a/src/self_destruct/health/handler.clj
+++ b/src/self_destruct/health/handler.clj
@@ -1,7 +1,8 @@
 (ns self-destruct.health.handler
   (:require [self-destruct.health.model :as health.model]
             [self-destruct.config       :as config])
-  (:require [cheshire.core :as json]))
+  (:require [cheshire.core :as json]
+            [taoensso.timbre :as timbre]))
 
 
 (defn handle-health [req]
@@ -11,8 +12,15 @@
 
 
 (defn handle-deep-health [req]
-  (let [healthy? (get (health.model/deep-health (config/db-url)) :exists)]
-    {:status 200
-     :headers {"Content-Type" "application/json"}
-     :body (json/generate-string {:healthy healthy?
-                                  :check-type "database connection"})}))
+  (try
+    (let [healthy? (boolean (:exists (health.model/deep-health (config/db-url))))]
+      {:status (if healthy? 200 503)
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:healthy healthy?
+                                    :check-type "database connection"})})
+    (catch Exception e
+      (timbre/error e "deep health check failed")
+      {:status 503
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:healthy false
+                                    :check-type "database connection"})})))

--- a/src/self_destruct/health/model.clj
+++ b/src/self_destruct/health/model.clj
@@ -1,0 +1,4 @@
+(ns self-destruct.health.model
+  (:require [hugsql.core :as hugsql]))
+
+(hugsql/def-db-fns "self_destruct/health/sql/health.sql")

--- a/src/self_destruct/health/route.clj
+++ b/src/self_destruct/health/route.clj
@@ -1,0 +1,8 @@
+(ns self-destruct.health.route
+  (:require [self-destruct.health.handler :as health.handler])
+  (:require [compojure.core :refer [defroutes GET]]))
+
+
+(defroutes health-routes
+  (GET  "/health"      [] health.handler/handle-health)
+  (GET  "/deep-health" [] health.handler/handle-deep-health))

--- a/src/self_destruct/health/sql/health.sql
+++ b/src/self_destruct/health/sql/health.sql
@@ -1,0 +1,12 @@
+-- src/self_destruct/health/sql/health.sql
+-- self-destruct health queries
+
+
+-- :name deep-health :? :n
+-- :doc verify db access
+select exists (
+  select 1
+  from information_schema.tables
+  where table_schema = 'public'
+  and table_name = 'message'
+  )

--- a/src/self_destruct/health/sql/health.sql
+++ b/src/self_destruct/health/sql/health.sql
@@ -2,7 +2,7 @@
 -- self-destruct health queries
 
 
--- :name deep-health :? :n
+-- :name deep-health :? :1
 -- :doc verify db access
 select exists (
   select 1

--- a/src/self_destruct/message/handler.clj
+++ b/src/self_destruct/message/handler.clj
@@ -46,14 +46,25 @@
                                             :iv message-iv})
         message-id        (message.model/create-message!
                            (config/db-url) {:message encrypted-message
-                                            :message-iv message-iv-hex})]
+                                            :message-iv message-iv-hex})
+        ;; we want to log a unique id, but not the entire id to avoid data leakage
+        message-log-id    (-> (util/uuid->str message-id)
+                              bc-hash/md5
+                              codecs/bytes->hex)
+        proxy-ip-chain    (get-in req [:headers "x-forwarded-for"])
+        client-ip         (if proxy-ip-chain
+                            (-> proxy-ip-chain
+                                (clojure.string/split #",")
+                                first)
+                            "localhost")]
     (if message-id
       (do
-        (timbre/info (str "message created: " (util/uuid->str message-id)))
+        (timbre/info
+         (str "message created: " message-log-id " by: " client-ip))
         ;; we use the referer to ensure relative links target the proxy, not the cluster ip
         (response/redirect (str referer "message/link/" (util/uuid->str message-id))))
       (do
-        (timbre/error (str "message creation failed..."))
+        (timbre/error (str "message creation failed... by: " client-ip))
         {:status 500
          :headers {"Content-Type" "application/json"}
          :body "{\"error\": \"message creation failed...\"}"}))))
@@ -62,14 +73,18 @@
 (defn handle-delete-message! [req]
   (let [referer    (get-in req [:headers "referer"])
         message-id (java.util.UUID/fromString (:message-id (:route-params req)))
+        ;; we want to log a unique id, but not the entire id to avoid data leakage
+        message-log-id    (-> (str message-id)
+                              bc-hash/md5
+                              codecs/bytes->hex)
         exists?    (message.model/delete-message!
                     (config/db-url) {:message-id message-id})]
     (if exists?
       (do
-        (timbre/info (str "message deleted: " message-id))
+        (timbre/info (str "message deleted: " message-log-id))
         (response/redirect (str referer "/")))
       (do
-        (timbre/error (str "message delete failed message id not found: " message-id))
+        (timbre/error (str "message delete failed message id not found: " message-log-id))
         (response/not-found "Message not found.")))))
 
 
@@ -79,19 +94,32 @@
 
 
 (defn handle-fetch-message [req]
-  (let [message-id   (java.util.UUID/fromString (:message-id (:route-params req)))
-        message      (message.model/read-message (config/db-url) {:message-id message-id})
-        message-text (when message (message :message))
-        deleted?     (message.model/delete-message! (config/db-url) {:message-id message-id})
-        message-iv   (when message (codecs/hex->bytes (message :message_iv)))
-        decrypted-message (when message (decrypt-message {:message message-text
-                                                          :encryption-key (config/db-encryption-key)
-                                                          :iv message-iv}))]
+  (let [message-id        (java.util.UUID/fromString (:message-id (:route-params req)))
+        ;; we want to log a unique id, but not the entire id to avoid data leakage
+        message-log-id    (-> (str message-id)
+                              bc-hash/md5
+                              codecs/bytes->hex)
+        message           (message.model/read-message (config/db-url) {:message-id message-id})
+        message-text      (when message (message :message))
+        deleted?          (message.model/delete-message! (config/db-url) {:message-id message-id})
+        message-iv        (when message (codecs/hex->bytes (message :message_iv)))
+        decrypted-message (when message (decrypt-message
+                                         {:message message-text
+                                          :encryption-key (config/db-encryption-key)
+                                          :iv message-iv}))
+        proxy-ip-chain    (get-in req [:headers "x-forwarded-for"])
+        client-ip         (if proxy-ip-chain
+                            (-> proxy-ip-chain
+                                (clojure.string/split #",")
+                                first)
+                            "localhost")]
     (if (and message deleted?)
       (do
-        (timbre/info (str "message accessed: " message-id))
-        (timbre/info (str "message deleted: " message-id))
+        (timbre/info (str "message accessed: " message-log-id " by: " client-ip))
+        (timbre/info (str "message deleted: " message-log-id))
         (message.view.index/message-page decrypted-message))
       (do
-        (timbre/error (str "failed to fetch message: " message-id))
-        (message.view.index/message-page "Message not found.")))))
+        (timbre/error (str "failed to fetch message: " message-log-id " by: " client-ip))
+        {:status 404
+         :headers {"Content-Type" "text/html"}
+         :body (message.view.index/message-page "Message not found.")}))))

--- a/src/self_destruct/message/handler.clj
+++ b/src/self_destruct/message/handler.clj
@@ -10,7 +10,7 @@
 
 (defn handle-create-message! [req]
   (let [message    (get-in req [:params :message])
-        message-id (message.model/create-message! db-url {:message message})]
+        message-id (message.model/create-message! (db-url) {:message message})]
     (do
       (timbre/info (str "message created: " (util/uuid->str message-id)))
       (response/redirect (str "/message/link/" (util/uuid->str message-id))))))
@@ -18,7 +18,7 @@
 
 (defn handle-delete-message! [req]
   (let [message-id (java.util.UUID/fromString (:message-id (:route-params req)))
-        exists? (message.model/delete-message! db-url {:message-id message-id})]
+        exists? (message.model/delete-message! (db-url) {:message-id message-id})]
     (if exists?
       (do
         (timbre/info (str "message deleted: " message-id))
@@ -35,8 +35,8 @@
 
 (defn handle-fetch-message [req]
   (let [message-id (java.util.UUID/fromString (:message-id (:route-params req)))
-        message    (message.model/read-message db-url {:message-id message-id})
-        deleted?   (message.model/delete-message! db-url {:message-id message-id})]
+        message    (message.model/read-message (db-url) {:message-id message-id})
+        deleted?   (message.model/delete-message! (db-url) {:message-id message-id})]
     (if (and message deleted?)
       (do
         (timbre/info (str "message accessed: " message-id))

--- a/src/self_destruct/message/handler.clj
+++ b/src/self_destruct/message/handler.clj
@@ -9,7 +9,8 @@
             [buddy.core.codecs  :as codecs]
             [buddy.core.nonce   :as nonce]
             [buddy.core.hash    :as hash]
-            [taoensso.timbre    :as timbre]))
+            [taoensso.timbre    :as timbre]
+            [clojure.string     :as str]))
 
 
 ;; helpers
@@ -35,91 +36,113 @@
         codecs/bytes->str)))
 
 
+(defn- message-log-id
+  "Hash a message id for logging so full secret ids are not written to logs."
+  [message-id]
+  (-> (str message-id)
+      hash/md5
+      codecs/bytes->hex))
+
+
+(defn- client-ip
+  [req]
+  (if-let [proxy-ip-chain (get-in req [:headers "x-forwarded-for"])]
+    (-> proxy-ip-chain
+        (str/split #",")
+        first
+        str/trim)
+    (or (:remote-addr req) "unknown")))
+
+
+(defn- parse-message-id
+  "Parse a route message id into a UUID. Returns nil when invalid."
+  [message-id-str]
+  (try
+    (java.util.UUID/fromString message-id-str)
+    (catch Exception _
+      nil)))
+
+
+(defn- blank-message?
+  [message]
+  (or (nil? message)
+      (str/blank? message)))
+
+
 ;; handlers
 (defn handle-create-message! [req]
-  (let [referer           (get-in req [:headers "referer"])
-        message           (get-in req [:params :message])
-        message-iv        (nonce/random-bytes 16)
-        message-iv-hex    (codecs/bytes->hex message-iv)
-        encrypted-message (encrypt-message {:message message
-                                            :encryption-key (config/db-encryption-key)
-                                            :iv message-iv})
-        message-id        (message.model/create-message!
-                           (config/db-url) {:message encrypted-message
-                                            :message-iv message-iv-hex})
-        ;; we want to log a unique id, but not the entire id to avoid data leakage
-        message-log-id    (-> (util/uuid->str message-id)
-                              bc-hash/md5
-                              codecs/bytes->hex)
-        proxy-ip-chain    (get-in req [:headers "x-forwarded-for"])
-        client-ip         (if proxy-ip-chain
-                            (-> proxy-ip-chain
-                                (clojure.string/split #",")
-                                first)
-                            "localhost")]
-    (if message-id
-      (do
-        (timbre/info
-         (str "message created: " message-log-id " by: " client-ip))
-        ;; we use the referer to ensure relative links target the proxy, not the cluster ip
-        (response/redirect (str referer "message/link/" (util/uuid->str message-id))))
-      (do
-        (timbre/error (str "message creation failed... by: " client-ip))
-        {:status 500
-         :headers {"Content-Type" "application/json"}
-         :body "{\"error\": \"message creation failed...\"}"}))))
+  (let [message (get-in req [:params :message])
+        ip      (client-ip req)]
+    (if (blank-message? message)
+      {:status 400
+       :headers {"Content-Type" "text/plain"}
+       :body "Message is required."}
+      (let [message-iv        (nonce/random-bytes 16)
+            message-iv-hex    (codecs/bytes->hex message-iv)
+            encrypted-message (encrypt-message {:message message
+                                                :encryption-key (config/db-encryption-key)
+                                                :iv message-iv})
+            message-id        (message.model/create-message!
+                               (config/db-url) {:message encrypted-message
+                                                :message-iv message-iv-hex})
+            log-id            (when message-id (message-log-id (util/uuid->str message-id)))]
+        (if message-id
+          (do
+            (timbre/info (str "message created: " log-id " by: " ip))
+            (response/redirect (str "/message/link/" (util/uuid->str message-id))))
+          (do
+            (timbre/error (str "message creation failed... by: " ip))
+            {:status 500
+             :headers {"Content-Type" "text/plain"}
+             :body "Message creation failed."}))))))
 
 
 (defn handle-delete-message! [req]
-  (let [referer    (get-in req [:headers "referer"])
-        message-id (java.util.UUID/fromString (:message-id (:route-params req)))
-        ;; we want to log a unique id, but not the entire id to avoid data leakage
-        message-log-id    (-> (str message-id)
-                              bc-hash/md5
-                              codecs/bytes->hex)
-        exists?    (message.model/delete-message!
-                    (config/db-url) {:message-id message-id})]
-    (if exists?
-      (do
-        (timbre/info (str "message deleted: " message-log-id))
-        (response/redirect (str referer "/")))
-      (do
-        (timbre/error (str "message delete failed message id not found: " message-log-id))
-        (response/not-found "Message not found.")))))
+  (if-let [message-id (parse-message-id (:message-id (:route-params req)))]
+    (let [log-id  (message-log-id message-id)
+          deleted (message.model/delete-message!
+                   (config/db-url) {:message-id message-id})]
+      (if (and (int? deleted) (pos? deleted))
+        (do
+          (timbre/info (str "message deleted: " log-id))
+          (response/redirect "/"))
+        (do
+          (timbre/error (str "message delete failed message id not found: " log-id))
+          (response/not-found "Message not found."))))
+    (response/not-found "Message not found.")))
 
 
 (defn handle-view-message-link [req]
-  (let [message-id (java.util.UUID/fromString (:message-id (:route-params req)))]
-    (message.view.link/link-page message-id)))
+  (if-let [message-id (parse-message-id (:message-id (:route-params req)))]
+    (message.view.link/link-page message-id)
+    (response/not-found "Message not found.")))
 
 
 (defn handle-fetch-message [req]
-  (let [message-id        (java.util.UUID/fromString (:message-id (:route-params req)))
-        ;; we want to log a unique id, but not the entire id to avoid data leakage
-        message-log-id    (-> (str message-id)
-                              bc-hash/md5
-                              codecs/bytes->hex)
-        message           (message.model/read-message (config/db-url) {:message-id message-id})
-        message-text      (when message (message :message))
-        deleted?          (message.model/delete-message! (config/db-url) {:message-id message-id})
-        message-iv        (when message (codecs/hex->bytes (message :message_iv)))
-        decrypted-message (when message (decrypt-message
-                                         {:message message-text
-                                          :encryption-key (config/db-encryption-key)
-                                          :iv message-iv}))
-        proxy-ip-chain    (get-in req [:headers "x-forwarded-for"])
-        client-ip         (if proxy-ip-chain
-                            (-> proxy-ip-chain
-                                (clojure.string/split #",")
-                                first)
-                            "localhost")]
-    (if (and message deleted?)
-      (do
-        (timbre/info (str "message accessed: " message-log-id " by: " client-ip))
-        (timbre/info (str "message deleted: " message-log-id))
-        (message.view.index/message-page decrypted-message))
-      (do
-        (timbre/error (str "failed to fetch message: " message-log-id " by: " client-ip))
-        {:status 404
-         :headers {"Content-Type" "text/html"}
-         :body (message.view.index/message-page "Message not found.")}))))
+  (if-let [message-id (parse-message-id (:message-id (:route-params req)))]
+    (let [log-id            (message-log-id message-id)
+          ip                (client-ip req)
+          ;; Atomic consume: delete and return content in one statement so
+          ;; concurrent fetches cannot both reveal the same message.
+          message           (message.model/fetch-message!
+                             (config/db-url) {:message-id message-id})
+          message-text      (when message (:message message))
+          message-iv        (when message (codecs/hex->bytes (:message_iv message)))
+          decrypted-message (when message
+                              (decrypt-message
+                               {:message message-text
+                                :encryption-key (config/db-encryption-key)
+                                :iv message-iv}))]
+      (if message
+        (do
+          (timbre/info (str "message accessed: " log-id " by: " ip))
+          (timbre/info (str "message deleted: " log-id))
+          (message.view.index/message-page decrypted-message))
+        (do
+          (timbre/error (str "failed to fetch message: " log-id " by: " ip))
+          {:status 404
+           :headers {"Content-Type" "text/html"}
+           :body (message.view.index/message-page "Message not found.")})))
+    {:status 404
+     :headers {"Content-Type" "text/html"}
+     :body (message.view.index/message-page "Message not found.")}))

--- a/src/self_destruct/message/sql/message.sql
+++ b/src/self_destruct/message/sql/message.sql
@@ -19,3 +19,9 @@ where id = :message-id
 -- :doc get a message by id
 select id, message, message_iv, date_created from message
 where id = :message-id
+
+
+-- :name expire-and-purge-messages! :! :n
+-- :doc remove messages from database that have not been read in :expire_minutes
+delete from message
+where date_created < now() - :expire-minutes::interval

--- a/src/self_destruct/message/sql/message.sql
+++ b/src/self_destruct/message/sql/message.sql
@@ -4,8 +4,8 @@
 
 -- :name create-message! :? :n
 -- :doc insert a message item, returning the id, thus the ? in the name rather than ! for execute
-insert into message (message)
-values (:message)
+insert into message (message, message_iv)
+values (:message, :message-iv)
 returning id
 
 
@@ -17,5 +17,5 @@ where id = :message-id
 
 -- :name read-message :? :n
 -- :doc get a message by id
-select id, message, date_created from message
+select id, message, message_iv, date_created from message
 where id = :message-id

--- a/src/self_destruct/message/sql/message.sql
+++ b/src/self_destruct/message/sql/message.sql
@@ -2,8 +2,8 @@
 -- self-destruct message queries
 
 
--- :name create-message! :? :n
--- :doc insert a message item, returning the id, thus the ? in the name rather than ! for execute
+-- :name create-message! :<! :1
+-- :doc insert a message item, returning the id
 insert into message (message, message_iv)
 values (:message, :message-iv)
 returning id
@@ -15,10 +15,17 @@ delete from message
 where id = :message-id
 
 
--- :name read-message :? :n
+-- :name read-message :? :1
 -- :doc get a message by id
 select id, message, message_iv, date_created from message
 where id = :message-id
+
+
+-- :name fetch-message! :<! :1
+-- :doc atomically delete and return a message by id (exactly-once consume)
+delete from message
+where id = :message-id
+returning id, message, message_iv, date_created
 
 
 -- :name expire-and-purge-messages! :! :n

--- a/src/self_destruct/message/worker.clj
+++ b/src/self_destruct/message/worker.clj
@@ -1,0 +1,31 @@
+(ns self-destruct.message.worker
+  (:require [self-destruct.config        :as config]
+            [self-destruct.message.model :as message.model])
+  (:require [environ.core    :as environ]
+            [tea-time.core   :as tt]
+            [taoensso.timbre :as timbre]))
+
+
+(defn expire-and-purge-messages
+  "purge unread messages after minutes of time has passed."
+  []
+  (let [message-expire-minutes (or (environ/env :message-expire-minutes) 1440)
+        ;; default to 24 hours (1440 minutes)
+        purged-messages-count (message.model/expire-and-purge-messages!
+                               (config/db-url)
+                               {:expire-minutes (str message-expire-minutes " minutes")})]
+    (if (int? purged-messages-count)
+      (if (> purged-messages-count 0)
+        (timbre/info (str purged-messages-count " expired messages successfully purged from database"))
+        (timbre/info "no expired messages to purge from database"))
+      (timbre/error "failed to run expire-and-purge-messages"))))
+
+
+(defn expire-and-purge-messages-scheduler
+  "run expire-and-purge-messages on a set schedule"
+  []
+  (let [worker-time-seconds (Integer/valueOf (or (environ/env :worker-delay-seconds) 3600))]
+    (tt/every!
+     worker-time-seconds ; run every ___ seconds
+     worker-time-seconds ; starting  ___ seconds from now
+     (bound-fn [] (expire-and-purge-messages)))))

--- a/src/self_destruct/route.clj
+++ b/src/self_destruct/route.clj
@@ -1,5 +1,6 @@
 (ns self-destruct.route
-  (:require [self-destruct.home.route    :as home.route]
+  (:require [self-destruct.health.route  :as health.route]
+            [self-destruct.home.route    :as home.route]
             [self-destruct.home.handler  :as home.handler]
             [self-destruct.message.route :as message.route])
   (:require [compojure.core  :refer [defroutes ANY GET POST PUT DELETE]]
@@ -15,6 +16,7 @@
 (def combined-routes
   ;; core-routes last so the not-found call is the last matching route
   (compojure/routes
+   health.route/health-routes
    home.route/home-routes
    message.route/message-routes
    core-routes))

--- a/src/self_destruct/worker.clj
+++ b/src/self_destruct/worker.clj
@@ -1,0 +1,18 @@
+(ns self-destruct.worker
+  (:require [self-destruct.message.worker :as message.worker])
+  (:require [environ.core    :as environ]
+            [tea-time.core   :as tt]
+            [taoensso.timbre :as timbre]))
+
+
+(defn launch-workers
+  "launch all application worker processes"
+  []
+  (let [enable-workers-env (environ/env :enable-workers)
+        enable-workers?    (when enable-workers-env (Boolean/valueOf enable-workers-env))]
+    ;; run workers by default, false must be set explicitly
+    (when (or (true? enable-workers?) (nil? enable-workers?))
+      ;; start tea timer thread pool
+      (tt/start!)
+      ;; run worker schedules
+      (message.worker/expire-and-purge-messages-scheduler))))

--- a/test/self_destruct/core_test.clj
+++ b/test/self_destruct/core_test.clj
@@ -1,13 +1,43 @@
 (ns self-destruct.core-test
-  (:require [clojure.test :refer :all]
-            [ring.mock.request :as mock]
-            [self-destruct.core :refer :all]))
+  (:require [self-destruct.core            :refer :all]
+            [self-destruct.message.handler :as    message.handler])
+  (:require [clojure.test      :refer :all]
+            [ring.mock.request :as    mock]
+            [buddy.core.nonce  :as    nonce]))
 
-(deftest test-app
+
+(deftest test-static-app-routes
   (testing "main route"
     (let [response (app (mock/request :get "/"))]
-      (is (= (:status response) 200))))
+      (is (= 200 (:status response)))))
 
   (testing "not-found route"
     (let [response (app (mock/request :get "/invalid"))]
-      (is (= (:status response) 404)))))
+      (is (= 404 (:status response)))))
+
+  (testing "health route"
+    (let [response (app (mock/request :get "/health"))]
+      (is (= 200 (:status response)))))
+
+  (testing "home route"
+    (let [response (app (mock/request :get "/home"))]
+      (is (= 200 (:status response))))))
+
+
+(deftest test-encryption-helpers
+  (let [message-iv        (nonce/random-bytes 16)
+        encryption-key    "changemedbkey1"
+        message           "test message"
+        encrypted-message (message.handler/encrypt-message
+                           {:message        message
+                            :iv             message-iv
+                            :encryption-key encryption-key})
+        decrypted-message (message.handler/decrypt-message
+                           {:message        encrypted-message
+                            :iv             message-iv
+                            :encryption-key encryption-key})]
+    (testing "encrypt message"
+      (is (not= message encrypted-message)))
+
+    (testing "decrypt message"
+      (is (= message decrypted-message)))))

--- a/test/self_destruct/core_test.clj
+++ b/test/self_destruct/core_test.clj
@@ -3,7 +3,8 @@
             [self-destruct.message.handler :as    message.handler])
   (:require [clojure.test      :refer :all]
             [ring.mock.request :as    mock]
-            [buddy.core.nonce  :as    nonce]))
+            [buddy.core.nonce  :as    nonce]
+            [cheshire.core     :as    json]))
 
 
 (deftest test-static-app-routes
@@ -16,8 +17,10 @@
       (is (= 404 (:status response)))))
 
   (testing "health route"
-    (let [response (app (mock/request :get "/health"))]
-      (is (= 200 (:status response)))))
+    (let [response (app (mock/request :get "/health"))
+          body     (json/parse-string (:body response) true)]
+      (is (= 200 (:status response)))
+      (is (true? (:healthy body)))))
 
   (testing "home route"
     (let [response (app (mock/request :get "/home"))]
@@ -41,3 +44,18 @@
 
     (testing "decrypt message"
       (is (= message decrypted-message)))))
+
+
+(deftest test-create-message-validation
+  (testing "blank message is rejected"
+    (let [response (app (-> (mock/request :post "/message/create")
+                            (mock/body {:message "   "})))]
+      (is (= 400 (:status response)))))
+
+  (testing "invalid message id returns not found on link route"
+    (let [response (app (mock/request :get "/message/link/not-a-uuid"))]
+      (is (= 404 (:status response)))))
+
+  (testing "invalid message id returns not found on fetch route"
+    (let [response (app (mock/request :get "/message/fetch/not-a-uuid"))]
+      (is (= 404 (:status response))))))

--- a/test/self_destruct/db_integration_test.clj
+++ b/test/self_destruct/db_integration_test.clj
@@ -1,0 +1,53 @@
+(ns self-destruct.db-integration-test
+  (:require [self-destruct.core             :refer :all]
+            [self-destruct.test.helper.core :as    test.helper])
+  (:require [clojure.test      :refer :all]
+            [ring.mock.request :as    mock]))
+
+
+;; ensure a clean db state for each test requiring db integration
+(use-fixtures :each test.helper/test-db-reset)
+
+
+(deftest test-db-app-routes
+  (testing "deep-health route"
+    (let [response (app (mock/request :get "/deep-health"))]
+      (is (= 200 (:status response))))))
+
+
+(deftest test-message-handlers
+  (testing "message create route"
+    (let [create-response (test.helper/create-test-message)]
+      (is (= 302 (:status create-response)))
+      (is (not= nil (:message-id create-response)))))
+
+  (testing "message delete route"
+    (let [create-response (test.helper/create-test-message)
+          delete-response (app
+                           (mock/request
+                            :post (str "/message/delete/" (:message-id create-response))))]
+      (is (= 302 (:status delete-response)))))
+
+  (testing "message link route"
+    (let [create-response (test.helper/create-test-message)
+          link-response   (app
+                           (mock/request
+                            :get (str "/message/link/" (:message-id create-response))))]
+      (is (= 200 (:status link-response)))))
+
+  (testing "message fetch route"
+    (let [create-response (test.helper/create-test-message)
+          fetch-response  (app
+                           (mock/request
+                            :get (str "/message/fetch/" (:message-id create-response))))]
+      (is (= 200 (:status fetch-response)))))
+
+  (testing "call message fetch route twice on same id"
+    (let [create-response (test.helper/create-test-message)
+          fetch-response  (app
+                           (mock/request
+                            :get (str "/message/fetch/" (:message-id create-response))))
+          fetch-response2 (app
+                           (mock/request
+                            :get (str "/message/fetch/" (:message-id create-response))))]
+      (is (= 404 (:status fetch-response2))))))

--- a/test/self_destruct/db_integration_test.clj
+++ b/test/self_destruct/db_integration_test.clj
@@ -1,8 +1,13 @@
 (ns self-destruct.db-integration-test
   (:require [self-destruct.core             :refer :all]
-            [self-destruct.test.helper.core :as    test.helper])
+            [self-destruct.test.helper.core :as    test.helper]
+            [self-destruct.message.model    :as    message.model]
+            [self-destruct.message.worker   :as    message.worker]
+            [self-destruct.config           :as    config])
   (:require [clojure.test      :refer :all]
-            [ring.mock.request :as    mock]))
+            [clojure.java.jdbc :as    jdbc]
+            [ring.mock.request :as    mock]
+            [cheshire.core     :as    json]))
 
 
 ;; ensure a clean db state for each test requiring db integration
@@ -11,22 +16,28 @@
 
 (deftest test-db-app-routes
   (testing "deep-health route"
-    (let [response (app (mock/request :get "/deep-health"))]
-      (is (= 200 (:status response))))))
+    (let [response (app (mock/request :get "/deep-health"))
+          body     (json/parse-string (:body response) true)]
+      (is (= 200 (:status response)))
+      (is (true? (:healthy body))))))
 
 
 (deftest test-message-handlers
   (testing "message create route"
     (let [create-response (test.helper/create-test-message)]
       (is (= 302 (:status create-response)))
-      (is (not= nil (:message-id create-response)))))
+      (is (not= nil (:message-id create-response)))
+      (is (re-matches #"[0-9a-fA-F-]{36}" (:message-id create-response)))))
 
   (testing "message delete route"
     (let [create-response (test.helper/create-test-message)
           delete-response (app
                            (mock/request
                             :post (str "/message/delete/" (:message-id create-response))))]
-      (is (= 302 (:status delete-response)))))
+      (is (= 302 (:status delete-response)))
+      (is (nil? (message.model/read-message
+                 (config/db-url)
+                 {:message-id (java.util.UUID/fromString (:message-id create-response))})))))
 
   (testing "message link route"
     (let [create-response (test.helper/create-test-message)
@@ -35,12 +46,17 @@
                             :get (str "/message/link/" (:message-id create-response))))]
       (is (= 200 (:status link-response)))))
 
-  (testing "message fetch route"
+  (testing "message fetch route returns content and deletes message"
     (let [create-response (test.helper/create-test-message)
+          message-id      (java.util.UUID/fromString (:message-id create-response))
           fetch-response  (app
                            (mock/request
                             :get (str "/message/fetch/" (:message-id create-response))))]
-      (is (= 200 (:status fetch-response)))))
+      (is (= 200 (:status fetch-response)))
+      (is (re-find #"test message" (:body fetch-response)))
+      (is (nil? (message.model/read-message
+                 (config/db-url)
+                 {:message-id message-id})))))
 
   (testing "call message fetch route twice on same id"
     (let [create-response (test.helper/create-test-message)
@@ -50,4 +66,26 @@
           fetch-response2 (app
                            (mock/request
                             :get (str "/message/fetch/" (:message-id create-response))))]
-      (is (= 404 (:status fetch-response2))))))
+      (is (= 200 (:status fetch-response)))
+      (is (= 404 (:status fetch-response2)))))
+
+  (testing "messages are stored encrypted"
+    (let [create-response (test.helper/create-test-message)
+          stored          (message.model/read-message
+                           (config/db-url)
+                           {:message-id (java.util.UUID/fromString (:message-id create-response))})]
+      (is (some? stored))
+      (is (not= "test message" (:message stored)))
+      (is (string? (:message_iv stored)))
+      (is (= 32 (count (:message_iv stored))))))
+
+  (testing "expired unread messages are purged"
+    (let [create-response (test.helper/create-test-message)
+          message-id      (java.util.UUID/fromString (:message-id create-response))]
+      (jdbc/execute! (config/db-url)
+                     ["update message set date_created = now() - interval '2 days' where id = ?"
+                      message-id])
+      (message.worker/expire-and-purge-messages)
+      (is (nil? (message.model/read-message
+                 (config/db-url)
+                 {:message-id message-id}))))))

--- a/test/self_destruct/test/helper/core.clj
+++ b/test/self_destruct/test/helper/core.clj
@@ -1,0 +1,28 @@
+(ns self-destruct.test.helper.core
+  (:require [self-destruct.core           :refer :all]
+            [self-destruct.test.helper.db :as    test.helper.db]
+            [self-destruct.config         :as    config])
+  (:require [ring.mock.request :as mock]))
+
+
+(defn test-db-reset
+  "run a function, resetting the test db before and after running it"
+  [test-function]
+  (do
+    (test.helper.db/test-clear-db! (config/db-url))
+    (test-function)
+    (test.helper.db/test-clear-db! (config/db-url))))
+
+
+(defn create-test-message
+  "create a test message returning a map containing the http-status-code and message-id"
+  []
+  (let [create-response (app (-> (mock/request :post "/message/create")
+                                 (mock/body {:message "test message"})))
+        status          (:status create-response)
+        message-id      (-> create-response
+                            (get-in [:headers "Location"])
+                            (clojure.string/split #"/")
+                            last)]
+    {:status     status
+     :message-id message-id}))

--- a/test/self_destruct/test/helper/db.clj
+++ b/test/self_destruct/test/helper/db.clj
@@ -1,0 +1,6 @@
+(ns self-destruct.test.helper.db
+  (:require [hugsql.core :as hugsql]))
+
+
+(hugsql/def-db-fns "self_destruct/test/helper/sql/helper.sql")
+(ns self-destruct.test.helper.db)

--- a/test/self_destruct/test/helper/db.clj
+++ b/test/self_destruct/test/helper/db.clj
@@ -3,4 +3,3 @@
 
 
 (hugsql/def-db-fns "self_destruct/test/helper/sql/helper.sql")
-(ns self-destruct.test.helper.db)

--- a/test/self_destruct/test/helper/sql/helper.sql
+++ b/test/self_destruct/test/helper/sql/helper.sql
@@ -1,0 +1,6 @@
+-- test/self_destruct/test/helper/sql/helper.sql
+-- self-destruct test helper queries
+
+-- :name test-clear-db! :!
+-- :doc truncate tables for clean test runs
+truncate message;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the long-open contrib work from PR #9 so these enhancements are merge-ready. Same tip commit is also on `201908-contrib` ([PR #9](https://github.com/chadhs/self-destruct/pull/9)); this PR is the reviewable, finished version.

### Features
- **Encryption at rest** with per-message IVs (`DATABASE_ENCRYPTION_KEY`)
- **Unread message expiry** via background worker (`MESSAGE_EXPIRE_MINUTES`, default 24h)
- **`/health`** and **`/deep-health`** endpoints
- **CLI**: `--port`, `--migrate`, `--help`
- **Heroku release-phase migrations** via `Procfile`
- Migrations no longer run as a side effect of app namespace load

### Fixes made while finishing the branch
- Replaced undefined `bc-hash/md5` with `buddy.core.hash`
- Corrected HugSQL result types (`:<! :1` / `:? :1`) for create/read/health
- Atomic one-time consume via `DELETE ... RETURNING` (`fetch-message!`)
- Relative redirects (removed fragile `Referer`-based Location URLs)
- Invalid UUID / blank message handling
- Deep-health returns **503** when unhealthy or DB errors
- Safe `message_iv` migration (purge then `NOT NULL`) + down migration
- Fixed broken duplicate `ns` in test DB helper
- CircleCI: app-container env vars, wait for Postgres, run migrations before tests
- Expanded unit/integration tests (28 assertions, all green locally)

### Production env vars
**Required:** `DATABASE_URL`, `DATABASE_ENCRYPTION_KEY`, `PORT`, `SESSION_COOKIE_KEY`  
**Optional:** `ENABLE_WORKERS`, `MESSAGE_EXPIRE_MINUTES`, `WORKER_DELAY_SECONDS`, `LOG_APPENDER`, `SENTRY_DSN`, `REPORTED_LOG_LEVEL`

### Test plan
- [x] `lein with-profile test test` — 28 assertions, 0 failures
- [x] `lein uberjar` builds
- [x] `java -jar target/self-destruct.jar --help` / `--migrate` works
- [ ] CircleCI green on this branch
- [ ] Manual smoke: create → link → fetch once → second fetch 404

**Note:** Existing unread plaintext messages are deleted by the IV migration (they cannot be re-encrypted in place).

After merge, PR #9 can be closed as superseded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb538-5278-78c2-b86d-82fb40736ce2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb538-5278-78c2-b86d-82fb40736ce2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

